### PR TITLE
Bartender is NO LONGER for ELITE EMPLOYEES!!

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -3,10 +3,6 @@
   name: job-name-bartender
   description: job-description-bartender
   playTimeTracker: JobBartender
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Civilian
-      time: 1800
   startingGear: BartenderGear
   icon: "JobIconBartender"
   supervisors: job-supervisors-hop


### PR DESCRIPTION
## About the PR
Bartender no-longer has a 30 minute job requirement.

## Why / Balance
This was an error. YOU ARE NO LONGER AN ELITE EMPLOYEE!

## Technical details
Just changes the bartender yaml in prototypes.

## Media
Nothing to show.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

<!--
:cl:
- fix: Bartender is NO LONGER for ELITE EMPLOYEES!!
-->
